### PR TITLE
[FIX] Arreglo el mail de contacto

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -58,7 +58,7 @@ const Footer = () => {
 
           <FooterLinksGroup>
             <FooterLinksTitle>Contacto</FooterLinksTitle>
-            <FooterLinks href="mailto:contacto@ututo.com.ar">contacto@ututo.com.ar</FooterLinks>
+            <FooterLinks href="mailto:contacto@ututo.ar">contacto@ututo.ar</FooterLinks>
           </FooterLinksGroup>
         </FooterLinksContainer>
       </Container>
@@ -82,7 +82,7 @@ const Footer = () => {
         <FooterText>
           Hecho con &#10084; por la comunidad
           <br/>
-          Ututo {currentYear}. 
+          Ututo {currentYear}.
         </FooterText>
       </FooterSocialLinks>
 


### PR DESCRIPTION
En la web publicada, el correo de contacto que aparece es contacto@ututo.com.ar.

Ututo.com.ar es web de un diario de Salta y @jpromanonet me dijo por Whatsapp que es incorrecto.

![image](https://github.com/user-attachments/assets/5ad1c0f3-61b5-4001-a979-ed3901e64a5c)

Cambios hechos:

```diff
<FooterLinks 
+     href="mailto:contacto@ututo.ar"
-     href="mailto:contacto@ututo.com.ar"
 >
+ contacto@ututo.ar
- contacto@ututo.com.ar
</FooterLinks>
```